### PR TITLE
disable certificate verification

### DIFF
--- a/src/Alma.php
+++ b/src/Alma.php
@@ -43,14 +43,14 @@ abstract class Alma
      * New Alma Client
      *
      * @param unknown $host Alma host
-     * @param unknown $api_key API key provided by your institution’s API administrator
+     * @param unknown $api_key API key provided by your institutionâ€™s API administrator
      */
     public function __construct($host, $api_key)
     {
         self::$host = rtrim($host, '/');
         self::$api_key = $api_key;
         
-        $this->client = new HttpClient();
+        $this->client = new HttpClient(['verify' => false]);
     }
 
     /**
@@ -59,7 +59,7 @@ abstract class Alma
     protected function client()
     {
         if (! $this->client instanceof HttpClient) {
-            $this->client = new HttpClient();
+            $this->client = new HttpClient(['verify' => false]);
         }
         
         return $this->client;


### PR DESCRIPTION
I was unable to connect to the API without this change. The API did not respond to port 80 so I switched to SSL by prepending https:// to the host. This got me a self signed certificate error so in the end I decided to switch of the SSL certificate verification altogether.

This "fix" is not very pretty but since ExLibris decided to use a self-signed certificate I think this is the only way to use the API at the moment