### PR TITLE
Guzzle requirement updated to ^6.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	],
 	"require" : {
 		"php" : ">=5.5",
-		"guzzlehttp/guzzle" : "6.3.3"
+		"guzzlehttp/guzzle" : "^6.4.0"
 	},
 	"require-dev" : {
 		"phpunit/phpunit" : "^4.0"


### PR DESCRIPTION
This is an alternative to #2 that jumps to 6.4.x instead of sticking with 6.3.x.